### PR TITLE
New filters, improvements and fixes

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -206,7 +206,8 @@ function duplicate_post_show_update_notice() {
 	$class   = 'notice is-dismissible';
 	$message = '<strong>' . sprintf(
 		/* translators: %s: Duplicate Post version. */
-		__( "What's new in Duplicate Post version %s:", 'duplicate-post' ), DUPLICATE_POST_CURRENT_VERSION
+		__( "What's new in Duplicate Post version %s:", 'duplicate-post' ),
+		DUPLICATE_POST_CURRENT_VERSION
 	) . '</strong><br/>';
 	$message .= esc_html__( 'Simple compatibility with Gutenberg user interface: enable "Admin bar" under the Settings', 'duplicate-post' ) . ' — '
 			. esc_html__( '"Slug" option unset by default on new installations', 'duplicate-post' ) . '<br/>';
@@ -383,7 +384,8 @@ function duplicate_post_save_as_new_post( $status = '' ) {
 					array(
 						'cloned' => 1,
 						'ids'    => $post->ID,
-					), $sendback
+					),
+					$sendback
 				)
 			);
 		} else {

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -229,7 +229,7 @@ function duplicate_post_show_update_notice() {
 		$message .= ' | <a id="duplicate-post-dismiss-notice" href="javascript:duplicate_post_dismiss_notice();">' .
 			__( 'Dismiss this notice.' ) . '</a>';
 	}
-	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '"><p>' . $message . '</p></div>';
+	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '"><p>' . $message . '</p></div>'; // XSS okay.
 	echo "<script>
 			function duplicate_post_dismiss_notice(){
 				var data = {
@@ -275,7 +275,7 @@ function duplicate_post_make_duplicate_link_row( $actions, $post ) {
 	 *
 	 * @return boolean
 	 */
-	if( apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy() && duplicate_post_is_post_type_enabled( $post->post_type ), $post ) ) {
+	if ( apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy() && duplicate_post_is_post_type_enabled( $post->post_type ), $post ) ) {
 		$actions['clone']             = '<a href="' . duplicate_post_get_clone_post_link( $post->ID, 'display', false ) . '" title="' .
 			esc_attr__( 'Clone this item', 'duplicate-post' ) . '">' . esc_html__( 'Clone', 'duplicate-post' ) . '</a>';
 		$actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link( $post->ID ) . '" title="' .
@@ -294,7 +294,7 @@ function duplicate_post_add_duplicate_post_button() {
 		$post = get_post( $id );
 
 		/** This filter is documented in wp-content/plugins/duplicate-post/duplicate-post-admin.php */
-		if( apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy() && duplicate_post_is_post_type_enabled( $post->post_type ), $post ) ) {
+		if ( apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy() && duplicate_post_is_post_type_enabled( $post->post_type ), $post ) ) {
 			?>
 <div id="duplicate-action">
 	<a class="submitduplicate duplication"
@@ -713,9 +713,9 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	 *
 	 * @return boolean
 	 */
-	$can_duplicate = apply_filters('duplicate_post_allow', true, $post, $status, $parent_id );
+	$can_duplicate = apply_filters( 'duplicate_post_allow', true, $post, $status, $parent_id );
 	if ( ! $can_duplicate ) {
-		wp_die( __( 'You aren\'t allowed to duplicate this post', 'duplicate-post' ) );
+		wp_die( esc_html( __( 'You aren\'t allowed to duplicate this post', 'duplicate-post' ) ) );
 	}
 
 	if ( ! duplicate_post_is_post_type_enabled( $post->post_type ) && 'attachment' !== $post->post_type ) {

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -208,7 +208,7 @@ function duplicate_post_add_css() {
 			duplicate_post_is_current_user_allowed_to_copy() &&
 			( $post_type_object->show_ui || 'attachment' === $current_object->post_type ) &&
 			( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
-				wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ) );
+				wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ), array(), DUPLICATE_POST_CURRENT_VERSION );
 		}
 	}
 }

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -150,7 +150,7 @@ function duplicate_post_admin_bar_render() {
 
 	// Fall back to post ID in admin screen.
 	if ( empty( $current_object ) && is_admin() && isset( $_GET['post'] ) ) {
-		$current_object = get_post( $_GET['post'] );
+		$current_object = get_post( intval( wp_unslash( $_GET['post'] ) ) );
 	}
 
 	if ( empty( $current_object ) ) {
@@ -158,22 +158,24 @@ function duplicate_post_admin_bar_render() {
 	}
 
 	/** This filter is documented in wp-content/plugins/duplicate_post/duplicate-post-admin.php */
-	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post($current_object->ID) ) ) {
+	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post( $current_object->ID ) ) ) {
 		return;
 	}
 
-	if ( ! empty( $current_object->post_type ) &&
-		( $post_type_object = get_post_type_object( $current_object->post_type ) ) &&
-		duplicate_post_is_current_user_allowed_to_copy() &&
-		( $post_type_object->show_ui || 'attachment' === $current_object->post_type ) &&
-		( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
-		$wp_admin_bar->add_menu(
-			array(
-				'id'    => 'new_draft',
-				'title' => esc_attr__( 'Copy to a new draft', 'duplicate-post' ),
-				'href'  => duplicate_post_get_clone_post_link( $current_object->ID ),
-			)
-		);
+	if ( ! empty( $current_object->post_type ) ) {
+		$post_type_object = get_post_type_object( $current_object->post_type );
+		if ( ! empty( $current_object->post_type ) &&
+			duplicate_post_is_current_user_allowed_to_copy() &&
+			( $post_type_object->show_ui || 'attachment' === $current_object->post_type ) &&
+			( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
+			$wp_admin_bar->add_menu(
+				array(
+					'id'    => 'new_draft',
+					'title' => esc_attr__( 'Copy to a new draft', 'duplicate-post' ),
+					'href'  => duplicate_post_get_clone_post_link( $current_object->ID ),
+				)
+			);
+		}
 	}
 }
 
@@ -188,7 +190,7 @@ function duplicate_post_add_css() {
 
 	// Fall back to post ID in admin screen.
 	if ( empty( $current_object ) && is_admin() && isset( $_GET['post'] ) ) {
-		$current_object = get_post( $_GET['post'] );
+		$current_object = get_post( intval( wp_unslash( $_GET['post'] ) ) );
 	}
 
 	if ( empty( $current_object ) ) {
@@ -196,7 +198,7 @@ function duplicate_post_add_css() {
 	}
 
 	/** This filter is documented in wp-content/plugins/duplicate_post/duplicate-post-admin.php */
-	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post($current_object->ID) ) ) {
+	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post( $current_object->ID ) ) ) {
 		return;
 	}
 

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Common functions
+ * Common functions.
  *
  * @package Duplicate Post
  * @since 2.0
  */
 
 /**
- * Tests if the user is allowed to copy posts
+ * Tests if the user is allowed to copy posts.
  *
  * @return bool
  */
@@ -16,7 +16,7 @@ function duplicate_post_is_current_user_allowed_to_copy() {
 }
 
 /**
- * Tests if post type is enable to be copied
+ * Tests if post type is enable to be copied.
  *
  * @param string $post_type The post type to check.
  * @return bool
@@ -30,7 +30,7 @@ function duplicate_post_is_post_type_enabled( $post_type ) {
 }
 
 /**
- * Wrapper for the option 'duplicate_post_create_user_level'
+ * Wrapper for the option 'duplicate_post_create_user_level'.
  *
  * @return mixed
  */
@@ -75,6 +75,13 @@ function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $dra
 	$post_type_object = get_post_type_object( $post->post_type );
 	if ( ! $post_type_object ) {
 		return;
+	}
+
+	// Classic editor legacy support.
+	if ( isset( $_GET['classic-editor'] )
+		|| ( $draft && function_exists( 'gutenberg_post_has_blocks' ) && ! gutenberg_post_has_blocks( $post ) )
+	) {
+		$action .= '&classic-editor';
 	}
 
 	return wp_nonce_url(
@@ -140,10 +147,23 @@ function duplicate_post_admin_bar_render() {
 	}
 	global $wp_admin_bar;
 	$current_object = get_queried_object();
+
+	// Fall back to post ID in admin screen.
+	if ( empty( $current_object ) && is_admin() && isset( $_GET['post'] ) ) {
+		$current_object = get_post( $_GET['post'] );
+	}
+
 	if ( empty( $current_object ) ) {
 		return;
 	}
-	if ( ! empty( $current_object->post_type ) && ( get_post_type_object( $current_object->post_type ) === $post_type_object ) &&
+
+	/** This filter is documented in wp-content/plugins/duplicate_post/duplicate-post-admin.php */
+	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post($current_object->ID) ) ) {
+		return;
+	}
+
+	if ( ! empty( $current_object->post_type ) &&
+		( $post_type_object = get_post_type_object( $current_object->post_type ) ) &&
 		duplicate_post_is_current_user_allowed_to_copy() &&
 		( $post_type_object->show_ui || 'attachment' === $current_object->post_type ) &&
 		( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
@@ -154,19 +174,6 @@ function duplicate_post_admin_bar_render() {
 				'href'  => duplicate_post_get_clone_post_link( $current_object->ID ),
 			)
 		);
-	} elseif ( is_admin() && isset( $_GET['post'] ) ) { // Input var okay.
-		$id   = intval( wp_unslash( $_GET['post'] ) ); // Input var okay.
-		$post = get_post( $id );
-		if ( duplicate_post_is_current_user_allowed_to_copy()
-				&& duplicate_post_is_post_type_enabled( $post->post_type ) ) {
-					$wp_admin_bar->add_menu(
-						array(
-							'id'    => 'new_draft',
-							'title' => esc_attr__( 'Copy to a new draft', 'duplicate-post' ),
-							'href'  => duplicate_post_get_clone_post_link( $id ),
-						)
-					);
-		}
 	}
 }
 
@@ -178,9 +185,21 @@ function duplicate_post_add_css() {
 		return;
 	}
 	$current_object = get_queried_object();
+
+	// Fall back to post ID in admin screen.
+	if ( empty( $current_object ) && is_admin() && isset( $_GET['post'] ) ) {
+		$current_object = get_post( $_GET['post'] );
+	}
+
 	if ( empty( $current_object ) ) {
 		return;
 	}
+
+	/** This filter is documented in wp-content/plugins/duplicate_post/duplicate-post-admin.php */
+	if ( ! apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy(), get_post($current_object->ID) ) ) {
+		return;
+	}
+
 	if ( ! empty( $current_object->post_type ) ) {
 		$post_type_object = get_post_type_object( $current_object->post_type );
 		if ( ! empty( $post_type_object ) &&
@@ -188,13 +207,6 @@ function duplicate_post_add_css() {
 			( $post_type_object->show_ui || 'attachment' === $current_object->post_type ) &&
 			( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
 				wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ) );
-		}
-	} elseif ( is_admin() && isset( $_GET['post'] ) ) { // Input var okay.
-		$id   = intval( wp_unslash( $_GET['post'] ) ); // Input var okay.
-		$post = get_post( $id );
-		if ( duplicate_post_is_current_user_allowed_to_copy()
-				&& duplicate_post_is_post_type_enabled( $post->post_type ) ) {
-					wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ) );
 		}
 	}
 }

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -362,7 +362,7 @@ img#donate-button {
 				<tr valign="top">
 					<th scope="row"><?php esc_html_e( 'Increase menu order by', 'duplicate-post' ); ?>
 					</th>
-					<td><input type="text" name="duplicate_post_increase_menu_order_by"
+					<td><input type="number" min="0" step="1" name="duplicate_post_increase_menu_order_by"
 						value="<?php echo esc_attr( get_option( 'duplicate_post_increase_menu_order_by' ) ); ?>" />
 					</td>
 					<td><span class="description"><?php esc_html_e( 'Add this number to the original menu order (blank or zero to retain the value)', 'duplicate-post' ); ?>


### PR DESCRIPTION
Following improvements are supplied with this PR.

### _duplicate-post-admin.php_

#### Added
 - `duplicate_post_show_link` filter allowing to display duplicate links.
 - `duplicate_post_new_post` filter allowing to modify new post data before insertion.
 - `duplicate_post_allow` filter allowing to duplicate single post.

#### Changed
 - Added `$post`, `$status` and `$parent_id` to `duplicate_post_pre_copy` action.
 - Added `$new_post_id`, `$post`, `$status` and `$parent_id` arguments to `duplicate_post_pre_copy` action
 - Forced `duplicate_post_create_duplicate` to return `WP_Error` on error.
 
#### Fixed
 - Removed HTML escaping for plugin notice.
 - Check result of `duplicate_post_create_duplicate`.
 - Fixed undefined `$post_type` variable.

### _duplicate-post-common.php_

#### Added
 - Updates new draft/clone links according to classic editor mode or Gutenberg post.
 - Applied `duplicate_post_show_link` filter.

#### Fixed
 - `$post_type_object` assignement in `duplicate_post_admin_bar_render`, `duplicate_post_add_css`   
 - Improved fall back to post ID in admin in order to display duplicate link in admin bar.

### _duplicate-post-options.php_

#### Changed
 - Used `number` type for `duplicate_post_increase_menu_order_by` option.