### PR TITLE
Fix phpcs errors

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -316,7 +316,7 @@ function duplicate_post_add_duplicate_post_button( $post = null ) {
 			?>
 <div id="duplicate-action">
 	<a class="submitduplicate duplication"
-		href="<?php echo esc_attr( duplicate_post_get_clone_post_link( $post->id ) ); ?>"><?php esc_html_e( 'Copy to a new draft', 'duplicate-post' ); ?>
+		href="<?php echo esc_url( duplicate_post_get_clone_post_link( $post->id ) ); ?>"><?php esc_html_e( 'Copy to a new draft', 'duplicate-post' ); ?>
 	</a>
 </div>
 			<?php

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -408,6 +408,7 @@ function duplicate_post_save_as_new_post( $status = '' ) {
 					$sendback
 				)
 			);
+			exit();
 		} else {
 			// Redirect to the edit screen for the new draft post.
 			wp_safe_redirect(
@@ -419,8 +420,8 @@ function duplicate_post_save_as_new_post( $status = '' ) {
 					admin_url( 'post.php?action=edit&post=' . $new_id . ( isset( $_GET['classic-editor'] ) ? '&classic-editor' : '' ) )
 				)
 			);
+			exit();
 		}
-		exit();
 	} else {
 		wp_die(
 			esc_html(

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -107,7 +107,7 @@ function duplicate_post_options() {
 		<?php esc_html_e( 'Donate whatever sum you choose, even just 10¢.', 'duplicate-post' ); ?>
 		<br /> <a href="https://duplicate-post.lopo.it/donate"><img
 				id="donate-button" style="margin: 0 auto;"
-				src="<?php echo esc_attr( plugins_url( 'donate.png', __FILE__ ) ); ?>"
+				src="<?php echo esc_url( plugins_url( 'donate.png', __FILE__ ) ); ?>"
 				alt="Donate" /></a> <br /> <a href="https://duplicate-post.lopo.it/"><?php esc_html_e( 'Documentation', 'duplicate-post' ); ?></a>
 			- <a
 				href="https://translate.wordpress.org/projects/wp-plugins/duplicate-post"><?php esc_html_e( 'Translate', 'duplicate-post' ); ?></a>


### PR DESCRIPTION
Here are two commits which fix errors that are returned by [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) if you run it against the [Automattic](https://github.com/Automattic/VIP-Coding-Standards) and [WordPress](https://github.com/WordPress/WordPress-Coding-Standards) coding standards.

The first one (moving the `exit()` around) has no security benefit, but it makes running this security tool easier. The code duplication is a little unfortunate, but it makes it possible to continue to use this useful heuristic without whitelisting anything.

The second (incorrect escaping function) could potentially lead to a vulnerability.